### PR TITLE
Install command fails with better errors. [semver:minor]

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -40,4 +40,16 @@ steps:
 
         HUGO_URL=https://github.com/gohugoio/hugo/releases/download/v<< parameters.version >>/hugo${HUGO_EXTENDED}_<< parameters.version >>_${OS}-64bit.${PKG_EXT}
 
-        curl -sSL "$HUGO_URL" | tar -xz -C /usr/local/bin hugo
+        # If the download fails...
+        if curl --fail -sSL "$HUGO_URL" 2>/dev/null | tar -xz -C /usr/local/bin hugo 2>/dev/null; then
+          echo "We're good, continue."
+        else
+          if [[ ! << parameters.version >> =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "Failed to install. The version number '<< parameters.version >>' is not a full valid SemVer version."
+          else
+            echo "Please choose a valid version from the Hugo tags page, without the leading 'v': https://github.com/gohugoio/hugo/tags"
+            echo "The download URL that failed was: ${HUGO_URL}"
+          fi
+
+          exit 1
+        fi


### PR DESCRIPTION
With this PR, when downloading Hugo fails, the error output from curl and tar/gzip are suppressed. Instead, when the error is due to not using a full SemVer version, you are told so. Otherwise, a download error message is given with the URL tried.


Fixes #26.