### PR TITLE
[semver:minor] install: Add support for AsciiDoc markup language

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -7,6 +7,10 @@ parameters:
     description: "Install the Hugo extended binary?"
     type: boolean
     default: true
+  asciidoc:
+    description: "Include support for AsciiDoc markup language?"
+    type: boolean
+    default: false
   install-location:
     description: "Location where the hugo binary should be installed."
     type: string
@@ -35,6 +39,9 @@ steps:
         # If we're in Alpine, install additional compatibility packages.
         if [[ $OSD_ID == "alpine" ]]; then
           apk add build-base curl libcurl libc6-compat libxml2-dev libxslt-dev
+          if [ << parameters.asciidoc >> = true ]; then
+            apk add asciidoc
+          fi
         fi
 
         if [ << parameters.extended >> = true ]; then

--- a/src/examples/build-and-test-asciidoc.yml
+++ b/src/examples/build-and-test-asciidoc.yml
@@ -1,0 +1,12 @@
+description: "Build a Hugo site with support for the AsciiDoc markup syntax."
+usage:
+  version: 2.1
+  orbs:
+    hugo: circleci/hugo@0.2
+  workflows:
+    main:
+      jobs:
+        - hugo/build:
+            version: "0.80.0"
+            asciidoc: true
+            html-proofer: true


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

This commit adds a new boolean parameter to install the `asciidoc` dependency if the boolean is set to true. I need this change in order to use this Orb for my Hugo site deploy with GitHub Pages.

### Description

I added logic to handle a new parameter if running inside an Alpine environment. If running in Alpine and AsciiDoc boolean is configured, install AsciiDoc.