### PR TITLE
asciidoc: Add to hugo-build, remove from install [semver:minor]

### DIFF
--- a/src/commands/hugo-build.yml
+++ b/src/commands/hugo-build.yml
@@ -16,7 +16,23 @@ parameters:
     description: "Additional flags to pass when running Hugo (e.g. -DF)."
     type: string
     default: ""
+  asciidoc:
+    description: "Include support for AsciiDoc markup language?"
+    type: boolean
+    default: false
 steps:
+  - run:
+      name: "Install AsciiDoc (if enabled)"
+      command: |
+        if [ << parameters.asciidoc >> = true ]; then
+          if [ ! -x /bin/apk ]; then
+            echo "Unsupported package manager. Need apk."
+            exit 1
+          else
+            apk add asciidoc
+          fi
+        fi
+
   - run:
       name: "Build with Hugo"
       command: "HUGO_ENV=<< parameters.hugo-env >> hugo -v -s << parameters.source >> -d << parameters.destination >> << parameters.extra-flags >>"

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -7,10 +7,6 @@ parameters:
     description: "Install the Hugo extended binary?"
     type: boolean
     default: true
-  asciidoc:
-    description: "Include support for AsciiDoc markup language?"
-    type: boolean
-    default: false
   install-location:
     description: "Location where the hugo binary should be installed."
     type: string
@@ -39,9 +35,6 @@ steps:
         # If we're in Alpine, install additional compatibility packages.
         if [[ $OSD_ID == "alpine" ]]; then
           apk add build-base curl libcurl libc6-compat libxml2-dev libxslt-dev
-          if [ << parameters.asciidoc >> = true ]; then
-            apk add asciidoc
-          fi
         fi
 
         if [ << parameters.extended >> = true ]; then

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -3,6 +3,10 @@ executor:
   name: default
   tag: << parameters.version >>
 parameters:
+  asciidoc:
+    description: "Include support for AsciiDoc markup language?"
+    type: boolean
+    default: false
   version:
     description: "Hugo version to use. Defaults to latest."
     type: string
@@ -41,6 +45,7 @@ steps:
           git submodule update --init --recursive
         fi
   - hugo-build:
+      asciidoc: "<< parameters.asciidoc >>"
       source: "<< parameters.source >>"
       destination: "<< parameters.destination >>"
       extra-flags: "<< parameters.hugo-extra-flags >>"


### PR DESCRIPTION
Closes #42.

### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

This commit fixes a broken implementation introduced in commit ac08b667d45e2a57d615d24a2a260fded6627337. 

### Description

AsciiDoc was mistakenly added to the Hugo installation step, when it actually needs to be available at run-time, not build-time. This moves the AsciiDoc check logic into the Hugo run-time part of the pipeline so AsciiDoc is available in the `$PATH` if needed.