### PR TITLE
Use Ubuntu, not Alpine, in hugo/build step [semver:patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,8 @@ jobs:
             rm ~/project/content/en/content-management/related.md
       - hugo/install:
           version: "0.78.0"
-      - hugo/hugo-build
+      - hugo/hugo-build:
+          asciidoc: true
       - run:
           name: "Basic Test"
           command: hugo version

--- a/src/commands/hugo-build.yml
+++ b/src/commands/hugo-build.yml
@@ -25,11 +25,13 @@ steps:
       name: "Install AsciiDoc (if enabled)"
       command: |
         if [ << parameters.asciidoc >> = true ]; then
-          if [ ! -x /bin/apk ]; then
-            echo "Unsupported package manager. Need apk."
+          if [[ $(grep ID_LIKE /etc/os-release) != "ID_LIKE=debian" ]]; then
+            echo "Unsupported Linux distribution. Need a Debian derivative (e.g. Ubuntu)."
             exit 1
           else
-            apk add asciidoc
+            if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
+            $SUDO apt-get update --yes
+            $SUDO apt-get install --yes asciidoctor
           fi
         fi
 


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

The `install` step uses Alpine, but the `hugo/build` step runs on Ubuntu
18.04. So, the check for `/bin/apk` fails. Now, there is a check if the
system is a Debian-like system (making an assumption that `apt-get` will
be in the `$PATH` somewhere). If the system is a Debian derivative
operating system, like Debian, it will install `asciidoctor`.

### Description

This commit makes a (hopeful) final fix for the AsciiDoc feature
addition. The step now uses `apt-get` instead of `apk`.

I verified and tested this change in a local Ubuntu 18.04 container. I
verified the scriptlet works and that the packages install correctly.