### PR TITLE
htmlproofer: Add new parameters for custom htmlproofer flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,10 @@ jobs:
           command: |
             git clone "https://github.com/gohugoio/hugoDocs.git" ~/project
             rm ~/project/content/en/content-management/related.md
-      - hugo/hugo-build
+      - hugo/hugo-build:
+          asciidoc: true
+          htmlproofer-http-status-ignore: "'0,400,503,999'"
+          htmlproofer-timeframe: "'1y'"
       - run:
           name: "Basic Test"
           command: hugo version
@@ -96,6 +99,8 @@ jobs:
           version: "0.78.0"
       - hugo/hugo-build:
           asciidoc: true
+          htmlproofer-http-status-ignore: "'0,400,503,999'"
+          htmlproofer-timeframe: "'1y'"
       - run:
           name: "Basic Test"
           command: hugo version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,10 +79,7 @@ jobs:
           command: |
             git clone "https://github.com/gohugoio/hugoDocs.git" ~/project
             rm ~/project/content/en/content-management/related.md
-      - hugo/hugo-build:
-          asciidoc: true
-          htmlproofer-http-status-ignore: "'0,400,503,999'"
-          htmlproofer-timeframe: "'1y'"
+      - hugo/hugo-build
       - run:
           name: "Basic Test"
           command: hugo version

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -35,6 +35,18 @@ parameters:
     description: "Additional flags to pass when running Hugo (e.g. -DF)."
     type: string
     default: ""
+  htmlproofer-http-status-ignore:
+    description: "An array of numbers representing status codes to ignore."
+    type: string
+    default: "''"
+  htmlproofer-url-ignore:
+    description: "An array of Strings or RegExps containing URLs that are safe to ignore. It affects all HTML attributes. Note that non-HTTP(S) URIs are always ignored."
+    type: string
+    default: "''"
+  htmlproofer-timeframe:
+    description: "A string representing the caching timeframe. The format is `[0-9]+[mhd]` where `m` stands for month, `h` for hours and `d` for days."
+    type: string
+    default: "'7d'"
 steps:
   - checkout
   - run:
@@ -54,6 +66,9 @@ steps:
       steps:
         - html-proofer:
             path: "<< parameters.source >>/<< parameters.destination >>"
+            http-status-ignore: "<< parameters.htmlproofer-http-status-ignore >>"
+            timeframe: "<< parameters.htmlproofer-timeframe >>"
+            url-ignore: "<< parameters.htmlproofer-url-ignore >>"
   - when:
       condition: << parameters.persist-to-workspace >>
       steps:

--- a/src/jobs/build.yml
+++ b/src/jobs/build.yml
@@ -46,7 +46,7 @@ parameters:
   htmlproofer-timeframe:
     description: "A string representing the caching timeframe. The format is `[0-9]+[mhd]` where `m` stands for month, `h` for hours and `d` for days."
     type: string
-    default: "'7d'"
+    default: "'1h'"
 steps:
   - checkout
   - run:


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

This allows me to use htmlproofer in my workflow. Most notably, I need
the `url-ignore` option because of some internal links that will always
be broken unless they are deliberately ignored.

### Description

This commit adds new parameters for custom flags and options to
htmlproofer. Since the htmlproofer command already has multiple options,
they only need to be exposed in the build settings.