### PR TITLE
html-proofer: Remove error-sort flag to restore error verbosity

### DIFF
--- a/src/commands/html-proofer.yml
+++ b/src/commands/html-proofer.yml
@@ -68,9 +68,9 @@ parameters:
     type: boolean
     default: true
   error-sort:
-    description: "Defines the sort order for error output. Can be `:path`, `:desc`, or `:status` (default: `:path`)."
+    description: "Defines the sort order for error output. Can be `:path`, `:desc`, or `:status`."
     type: string
-    default: ':path'
+    default: "''"
   enforce-https:
     description: "Fails a link if it's not marked as `https` (default: `false`)."
     type: boolean
@@ -167,7 +167,7 @@ steps:
           --directory-index-file << parameters.directory-index-file >> \
           <<# parameters.disable-external >> --disable-external <</ parameters.disable-external >> \
           <<# parameters.empty-alt-ignore >> --empty-alt-ignore <</ parameters.empty-alt-ignore >> \
-          --error-sort << parameters.error-sort >> \
+          <<# parameters.error-sort >>--error-sort << parameters.error-sort >> <</ parameters.error-sort >> \
           <<# parameters.enforce-https >> --enforce-https <</ parameters.enforce-https >> \
           --extension << parameters.extension >> \
           <<# parameters.external_only >> --external_only <</ parameters.external_only >> \


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

This commit removes the `error-sort` flag from the `htmlproofer` command
in order to restore logs from HTML Proofer in the Circle CI build
report.

The current behavior with this flag added is to suppress all error
messages, which is not helpful when you have a failing CI pipeline from
HTML Proofer. To debug requires a local checkout of the repo and to
manually run HTML Proofer to see the errors.

### Description

I tested this change locally and verified that removing this flag
restores the errors in log messages. This is an uncommon flag to use for
HTML Proofer, and I think it does not do exactly what it is expected to
do, so the best option appears to be removing it, thus simplifying what
needs to be maintained here.