### PR TITLE
fix: add explicit true for htmlproofer options

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -9,7 +9,7 @@ jobs:
   integration-test-hugo:
     executor:
       name: hugo/default
-      tag: "0.105.0"
+      tag: "0.120.4"
     steps:
       - run:
           name: "Check out Hugo Docs as a sample project."
@@ -30,7 +30,7 @@ jobs:
             git clone "https://github.com/gohugoio/hugoDocs.git" ~/project
             rm ~/project/content/en/content-management/related.md
       - hugo/install:
-          version: "0.105.0"
+          version: "0.120.4"
       - hugo/hugo-build
       - run:
           name: "Basic Test"
@@ -45,7 +45,7 @@ jobs:
             git clone "https://github.com/gohugoio/hugoDocs.git" ~/project
             rm ~/project/content/en/content-management/related.md
       - hugo/install:
-          version: "0.105.0"
+          version: "0.120.4"
       - hugo/hugo-build
       - run:
           name: "Basic Test"

--- a/src/scripts/html_proofer.sh
+++ b/src/scripts/html_proofer.sh
@@ -45,7 +45,7 @@ for (( i = 0; i < ${#check_flags[@]} / 2; i++ )); do
     if [ "$flag_enabled" = 1 ]; then
         # add the flag to the array 
         arg_index=$((real_index + 1))
-        flags+=("${check_flags[$arg_index]}")
+        flags+=("${check_flags[$arg_index]} true")
     fi
 done
 


### PR DESCRIPTION
Fixes CircleCI-Public/hugo-orb#57 because of gjtorikian/html-proofer#738.

### Checklist

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

This change makes boolean command line options for htmlproofer explicit because of the change made in gjtorikian/html-proofer#738. It fixes CircleCI-Public/hugo-orb#57.

### Description
add "true" to the flags array in html_proofer.sh