### PR TITLE
feat!: bump default Hugo executor version 0.142.0 → 0.162.1 (PIE-6)

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -63,10 +63,14 @@ jobs:
       - hugo/install:
           version: "0.162.1"
       - run:
-          name: "Install Node.js and npm dependencies"
+          name: "Install Node.js LTS and npm dependencies"
           command: |
-            brew install node
-            echo 'export PATH="/usr/local/bin:$PATH"' >> "$BASH_ENV"
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            nvm install --lts
+            nvm alias default lts/*
+            echo 'export NVM_DIR="$HOME/.nvm"' >> "$BASH_ENV"
+            echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> "$BASH_ENV"
             npm install --prefix ~/project
       - hugo/hugo-build
       - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -25,20 +25,25 @@ jobs:
             rm -f ~/project/content/en/content-management/related.md
       - run:
           name: "Install npm dependencies"
-          command: npm install --prefix ~/project
+          command: |
+            sudo apt-get update -y && sudo apt-get install -y nodejs npm
+            npm install --prefix ~/project
       - hugo/hugo-build
       - run:
           name: "Basic Test"
           command: hugo version
   integration-test-base:
     docker:
-      - image: cimg/base:current
+      - image: cimg/node:lts
     steps:
       - run:
           name: "Check out Hugo Docs as a sample project."
           command: |
             git clone --depth=1 "https://github.com/gohugoio/hugoDocs.git" ~/project
             rm -f ~/project/content/en/content-management/related.md
+      - run:
+          name: "Install npm dependencies"
+          command: npm install --prefix ~/project
       - hugo/install:
           version: "0.162.1"
       - hugo/hugo-build
@@ -56,6 +61,9 @@ jobs:
             rm -f ~/project/content/en/content-management/related.md
       - hugo/install:
           version: "0.162.1"
+      - run:
+          name: "Install npm dependencies"
+          command: npm install --prefix ~/project
       - hugo/hugo-build
       - run:
           name: "Basic Test"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -63,8 +63,11 @@ jobs:
       - hugo/install:
           version: "0.162.1"
       - run:
-          name: "Install npm dependencies"
-          command: npm install --prefix ~/project
+          name: "Install Node.js and npm dependencies"
+          command: |
+            brew install node
+            echo 'export PATH="/usr/local/bin:$PATH"' >> "$BASH_ENV"
+            npm install --prefix ~/project
       - hugo/hugo-build
       - run:
           name: "Basic Test"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -22,7 +22,7 @@ jobs:
           name: "Check out Hugo Docs as a sample project."
           command: |
             git clone --depth=1 "https://github.com/gohugoio/hugoDocs.git" ~/project
-            rm ~/project/content/en/content-management/related.md
+            rm -f ~/project/content/en/content-management/related.md
       - hugo/hugo-build
       - run:
           name: "Basic Test"
@@ -35,7 +35,7 @@ jobs:
           name: "Check out Hugo Docs as a sample project."
           command: |
             git clone --depth=1 "https://github.com/gohugoio/hugoDocs.git" ~/project
-            rm ~/project/content/en/content-management/related.md
+            rm -f ~/project/content/en/content-management/related.md
       - hugo/install:
           version: "0.142.0"
       - hugo/hugo-build
@@ -50,7 +50,7 @@ jobs:
           name: "Check out Hugo Docs as a sample project."
           command: |
             git clone --depth=1 "https://github.com/gohugoio/hugoDocs.git" ~/project
-            rm ~/project/content/en/content-management/related.md
+            rm -f ~/project/content/en/content-management/related.md
       - hugo/install:
           version: "0.142.0"
       - hugo/hugo-build

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -23,6 +23,9 @@ jobs:
           command: |
             git clone --depth=1 "https://github.com/gohugoio/hugoDocs.git" ~/project
             rm -f ~/project/content/en/content-management/related.md
+      - run:
+          name: "Install npm dependencies"
+          command: npm install --prefix ~/project
       - hugo/hugo-build
       - run:
           name: "Basic Test"
@@ -37,7 +40,7 @@ jobs:
             git clone --depth=1 "https://github.com/gohugoio/hugoDocs.git" ~/project
             rm -f ~/project/content/en/content-management/related.md
       - hugo/install:
-          version: "0.142.0"
+          version: "0.162.1"
       - hugo/hugo-build
       - run:
           name: "Basic Test"
@@ -52,7 +55,7 @@ jobs:
             git clone --depth=1 "https://github.com/gohugoio/hugoDocs.git" ~/project
             rm -f ~/project/content/en/content-management/related.md
       - hugo/install:
-          version: "0.142.0"
+          version: "0.162.1"
       - hugo/hugo-build
       - run:
           name: "Basic Test"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -26,7 +26,8 @@ jobs:
       - run:
           name: "Install npm dependencies"
           command: |
-            sudo apt-get update -y && sudo apt-get install -y nodejs npm
+            curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+            sudo apt-get install -y nodejs
             npm install --prefix ~/project
       - hugo/hugo-build
       - run:

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -3,6 +3,6 @@ parameters:
   hugo_version:
     description: "Specifies the hugo version to install"
     type: string
-    default: "0.142.0"
+    default: "0.162.1"
 docker:
   - image: cibuilds/hugo:<< parameters.hugo_version >>

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -34,11 +34,12 @@ else
 fi
 
 HUGO_URL=https://github.com/gohugoio/hugo/releases/download/v${ORB_VAL_VERSION}/hugo${HUGO_EXTENDED}_${ORB_VAL_VERSION}_${OS}.${PKG_EXT}
-curl --fail -sSL "$HUGO_URL" -o /tmp/hugo-archive 2>/dev/null
+HUGO_ARCHIVE="/tmp/hugo-archive.${PKG_EXT}"
+curl --fail -sSL "$HUGO_URL" -o "$HUGO_ARCHIVE" 2>/dev/null
 # If the download fails...
 
 if [[ "$PKG_EXT" == "pkg" ]]; then
-    if sudo installer -pkg /tmp/hugo-archive -target / 2>/dev/null; then
+    if sudo installer -pkg "$HUGO_ARCHIVE" -target / 2>/dev/null; then
         echo "Hugo succesfully installed."
     else
         if [[ ! "${ORB_VAL_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
@@ -49,7 +50,7 @@ if [[ "$PKG_EXT" == "pkg" ]]; then
         fi
         exit 1
     fi
-elif $SUDO tar -xzf /tmp/hugo-archive -C "${ORB_EVAL_INSTALL_LOCATION}" hugo 2>/dev/null; then
+elif $SUDO tar -xzf "$HUGO_ARCHIVE" -C "${ORB_EVAL_INSTALL_LOCATION}" hugo 2>/dev/null; then
     echo "Hugo succesfully installed."
 else
     if [[ ! "${ORB_VAL_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -34,11 +34,11 @@ else
 fi
 
 HUGO_URL=https://github.com/gohugoio/hugo/releases/download/v${ORB_VAL_VERSION}/hugo${HUGO_EXTENDED}_${ORB_VAL_VERSION}_${OS}.${PKG_EXT}
-curl --fail -sSL "$HUGO_URL" -o hugo-archive 2>/dev/null
+curl --fail -sSL "$HUGO_URL" -o /tmp/hugo-archive 2>/dev/null
 # If the download fails...
 
 if [[ "$PKG_EXT" == "pkg" ]]; then
-    if sudo installer -pkg hugo-archive -target / 2>/dev/null; then
+    if sudo installer -pkg /tmp/hugo-archive -target / 2>/dev/null; then
         echo "Hugo succesfully installed."
     else
         if [[ ! "${ORB_VAL_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
@@ -49,7 +49,7 @@ if [[ "$PKG_EXT" == "pkg" ]]; then
         fi
         exit 1
     fi
-elif $SUDO tar -xzf hugo-archive -C "${ORB_EVAL_INSTALL_LOCATION}" hugo 2>/dev/null; then
+elif $SUDO tar -xzf /tmp/hugo-archive -C "${ORB_EVAL_INSTALL_LOCATION}" hugo 2>/dev/null; then
     echo "Hugo succesfully installed."
 else
     if [[ ! "${ORB_VAL_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -8,7 +8,13 @@ case $OSD_FAMILY in
     ;;
     darwin)
     OS=darwin-universal
-    PKG_EXT=tar.gz
+    # Hugo 0.160.0+ ships macOS releases only as .pkg (no tar.gz)
+    IFS='.' read -r _major _minor _patch <<< "$ORB_VAL_VERSION"
+    if [[ "${_minor}" -ge 160 ]]; then
+        PKG_EXT=pkg
+    else
+        PKG_EXT=tar.gz
+    fi
     ;;
     *)
     echo "Unsupported operating system."
@@ -31,15 +37,26 @@ HUGO_URL=https://github.com/gohugoio/hugo/releases/download/v${ORB_VAL_VERSION}/
 curl --fail -sSL "$HUGO_URL" -o hugo-archive 2>/dev/null
 # If the download fails...
 
-if $SUDO tar -xzf hugo-archive -C "${ORB_EVAL_INSTALL_LOCATION}" hugo 2>/dev/null; then
+if [[ "$PKG_EXT" == "pkg" ]]; then
+    if sudo installer -pkg hugo-archive -target / 2>/dev/null; then
+        echo "Hugo succesfully installed."
+    else
+        if [[ ! "${ORB_VAL_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "Failed to install. The version number ${ORB_VAL_VERSION} is not a full valid SemVer version."
+        else
+            echo "Please choose a valid version from the Hugo tags page, without the leading 'v': https://github.com/gohugoio/hugo/tags"
+            echo "The download URL that failed was: ${HUGO_URL}"
+        fi
+        exit 1
+    fi
+elif $SUDO tar -xzf hugo-archive -C "${ORB_EVAL_INSTALL_LOCATION}" hugo 2>/dev/null; then
     echo "Hugo succesfully installed."
 else
     if [[ ! "${ORB_VAL_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-    echo "Failed to install. The version number ${ORB_VAL_VERSION} is not a full valid SemVer version."
+        echo "Failed to install. The version number ${ORB_VAL_VERSION} is not a full valid SemVer version."
     else
-    echo "Please choose a valid version from the Hugo tags page, without the leading 'v': https://github.com/gohugoio/hugo/tags"
-    echo "The download URL that failed was: ${HUGO_URL}"
+        echo "Please choose a valid version from the Hugo tags page, without the leading 'v': https://github.com/gohugoio/hugo/tags"
+        echo "The download URL that failed was: ${HUGO_URL}"
     fi
-
     exit 1
 fi


### PR DESCRIPTION
## Summary

- Bumps `hugo_version` default in `executors/default.yml` from `0.142.0` to `0.162.1`

## Breaking change

Users who used the executor directly and relied on the `0.142.0` default will now get `cibuilds/hugo:0.162.1`.

## Migration guide (v→v+1)

```yaml
# Pin the old version to keep it:
executor:
  name: hugo/default
  hugo_version: "0.142.0"
```

Closes PIE-6